### PR TITLE
updated for python 3.0

### DIFF
--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -305,12 +305,12 @@ class XMODEM(object):
                     filename = filenames.pop()
                     stream = open(filename, 'rb')
                     stat = os.stat(filename)
-                    data = os.path.basename(filename) + NUL + str(stat.st_size)
+                    data = os.path.basename(filename).encode() + NUL + str(stat.st_size).encode()
                     self.log.debug('ymodem sending : "%s" len:%d', filename, stat.st_size)
                 else:
                     # empty file name packet terminates transmission
                     filename = ''
-                    data = ''
+                    data = ''.encode()
                     stream = None
                     self.log.debug('ymodem done, sending empty header.')
                 if len(data) <= 128:


### PR DESCRIPTION
in python 3.0 strings must be explicitly converted to bytes using encode()
https://docs.python.org/3/library/stdtypes.html#str.encode